### PR TITLE
Tech-News Moderation

### DIFF
--- a/applications/news_moderation.go
+++ b/applications/news_moderation.go
@@ -74,7 +74,7 @@ func (r ModerateNewsRule) OnMessage(ctx framework.MessageContext, channel *disco
 	}
 
 	// Send a direct message to the user
-	ctx.Session().ChannelMessageSend(dmChannel.ID, violation.Error())
+	ctx.Session().ChannelMessageSend(dmChannel.ID, "**Error**: "+violation.Error())
 
 	// Send a copy of the original content to the user
 	sendOriginalMessageAsCodeblock(ctx, dmChannel.ID, content)

--- a/applications/news_moderation.go
+++ b/applications/news_moderation.go
@@ -54,8 +54,10 @@ func (r ModerateNewsRule) OnMessage(ctx framework.MessageContext, channel *disco
 		return
 	}
 
+	content := ctx.Message().Content
+
 	// Test the message content
-	violation := r.test(ctx.Message().Content)
+	violation := r.test(content)
 	if violation == nil {
 		return
 	}
@@ -73,6 +75,9 @@ func (r ModerateNewsRule) OnMessage(ctx framework.MessageContext, channel *disco
 
 	// Send a direct message to the user
 	ctx.Session().ChannelMessageSend(dmChannel.ID, violation.Error())
+
+	// Send a copy of the original content to the user
+	sendOriginalMessageAsCodeblock(ctx, dmChannel.ID, content)
 }
 
 // Tests the rule against the content

--- a/applications/rss_moderation.go
+++ b/applications/rss_moderation.go
@@ -54,8 +54,10 @@ func (r ModerateRSSRule) OnMessage(ctx framework.MessageContext, channel *discor
 		return
 	}
 
+	content := ctx.Message().Content
+
 	// Test the message content
-	violation := r.test(ctx.Message().Content)
+	violation := r.test(content)
 	if violation == nil {
 		return
 	}
@@ -73,6 +75,9 @@ func (r ModerateRSSRule) OnMessage(ctx framework.MessageContext, channel *discor
 
 	// Send a direct message to the user
 	ctx.Session().ChannelMessageSend(dmChannel.ID, violation.Error())
+
+	// Send a copy of the original content to the user
+	sendOriginalMessageAsCodeblock(ctx, dmChannel.ID, content)
 }
 
 // Tests the rule against the content

--- a/applications/rss_moderation.go
+++ b/applications/rss_moderation.go
@@ -74,7 +74,7 @@ func (r ModerateRSSRule) OnMessage(ctx framework.MessageContext, channel *discor
 	}
 
 	// Send a direct message to the user
-	ctx.Session().ChannelMessageSend(dmChannel.ID, violation.Error())
+	ctx.Session().ChannelMessageSend(dmChannel.ID, "**Error**: "+violation.Error())
 
 	// Send a copy of the original content to the user
 	sendOriginalMessageAsCodeblock(ctx, dmChannel.ID, content)

--- a/applications/utils.go
+++ b/applications/utils.go
@@ -1,0 +1,23 @@
+package applications
+
+import (
+	"strings"
+
+	"github.com/aussiebroadwan/tony/framework"
+)
+
+func sendOriginalMessageAsCodeblock(ctx framework.MessageContext, channelId, content string) {
+	// Convert all ` to ' to avoid code block formatting
+	content = strings.ReplaceAll(content, "`", "'")
+
+	// truncate the content to 2000 characters - the code block will add 6 characters plus the markdown label (2) and the newlines (2) = 10
+	if len(content) > 2000-10 {
+		content = content[:2000-10]
+	}
+
+	// Convert the content to a code block
+	content = "```md\n" + content + "\n```"
+
+	// Send a copy of the original content to the user
+	ctx.Session().ChannelMessageSend(channelId, content)
+}


### PR DESCRIPTION
Closes #37 

This PR adds to the error messages that is directly messaged to the user on the even of failed formatting in moderated channels such as `#tech-news`. This has also been added to the `#rss` channel for consistency. 